### PR TITLE
(#8) informative dropdown text

### DIFF
--- a/main.c
+++ b/main.c
@@ -817,15 +817,15 @@ static void new_window(GApplication *app, FilesToOpen f)
 		if(sorted_names == NULL){
 			csa_warning("failed to allocate memory to sort static map names, so they are being left unsorted.\n");
 			for(int i = 0; names[i] != NULL; ++i){
-				gtk_combo_box_text_prepend_text((GtkComboBoxText*)data->gui_elems.captain_map_dropdown, names[i]);
-				gtk_combo_box_text_prepend_text((GtkComboBoxText*)data->gui_elems.radio_engineer_map_dropdown, names[i]);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(data->gui_elems.captain_map_dropdown), names[i]);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(data->gui_elems.radio_engineer_map_dropdown), names[i]);
 			}
 		}else{
 			memcpy(sorted_names, names, sizeof(char*) * len);
 			qsort(sorted_names, len, sizeof(char*), sort_map_names);
 			for(int i = 0; i < len; ++i){
-				gtk_combo_box_text_prepend_text((GtkComboBoxText*)data->gui_elems.captain_map_dropdown, sorted_names[i]);
-				gtk_combo_box_text_prepend_text((GtkComboBoxText*)data->gui_elems.radio_engineer_map_dropdown, sorted_names[i]);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(data->gui_elems.captain_map_dropdown), sorted_names[i]);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(data->gui_elems.radio_engineer_map_dropdown), sorted_names[i]);
 			}
 			csa_free(sorted_names);
 		}

--- a/main.c
+++ b/main.c
@@ -1254,7 +1254,7 @@ static void open_map(GApplication *application, GFile **files, int n_files, __at
 										is_static = FALSE;
 									}
 								}
-							}else{
+							}else if(fmt[ind] != 'r'){ // we won't catch 'r' until the second iteration, it is still valid
 								csa_warning("invalid format specifier unit '%c' is being ignored.\n", fmt[ind]);
 								break;
 							}

--- a/main.c
+++ b/main.c
@@ -573,6 +573,17 @@ static void escape_activate (
 	reset_ui_action(NULL, user_data);
 }
 
+const char* crop_to_filename(const char *path)
+{
+	const char *filename = path;
+	for(int i = 0; path[i] != '\0'; ++i){
+		if(path[i] == '/'){
+			filename = path + i + 1;
+		}
+	}
+	return filename;
+}
+
 static void new_window(GApplication *app, FilesToOpen f)
 {
 	// create program data storage
@@ -918,7 +929,12 @@ static void new_window(GApplication *app, FilesToOpen f)
 		// file past the syntax checker anyway though.
 		if(f.type & LOAD_FIRST){
 			if(!init_tracker(data, f.file1, f.type & STATIC_FIRST ? FROM_STRING : FROM_FILE, TRUE)){
-				gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(data->gui_elems.captain_map_dropdown), GTK_SENSITIVITY_OFF);
+				GtkComboBox *dropdown = GTK_COMBO_BOX(data->gui_elems.captain_map_dropdown);
+				gtk_combo_box_set_button_sensitivity(dropdown, GTK_SENSITIVITY_OFF);
+				g_signal_handlers_block_by_func(dropdown, (void*)captain_dropdown_fix, data);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(dropdown), crop_to_filename(f.file1));
+				gtk_combo_box_set_active(dropdown, 0);
+				g_signal_handlers_unblock_by_func(dropdown, (void*)captain_dropdown_fix, data);
 				gtk_widget_queue_draw(GTK_WIDGET(data->gui_elems.captain_drawing_area));
 				gtk_widget_queue_draw(GTK_WIDGET(data->gui_elems.captain_self_tracking));
 			}else{
@@ -927,7 +943,12 @@ static void new_window(GApplication *app, FilesToOpen f)
 		}
 		if(f.type & LOAD_SECOND){
 			if(!init_tracker(data, f.file2, f.type & STATIC_SECOND ? FROM_STRING : FROM_FILE, FALSE)){
-				gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(data->gui_elems.radio_engineer_map_dropdown), GTK_SENSITIVITY_OFF);
+				GtkComboBox *dropdown = GTK_COMBO_BOX(data->gui_elems.radio_engineer_map_dropdown);
+				gtk_combo_box_set_button_sensitivity(dropdown, GTK_SENSITIVITY_OFF);
+				g_signal_handlers_block_by_func(dropdown, (void*)radio_engineer_dropdown_fix, data);
+				gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(dropdown), crop_to_filename(f.file2));
+				gtk_combo_box_set_active(dropdown, 0);
+				g_signal_handlers_unblock_by_func(dropdown, (void*)radio_engineer_dropdown_fix, data);
 				gtk_widget_queue_draw(GTK_WIDGET(data->gui_elems.radio_engineer_drawing_area));
 			}else{
 				error_popup(data, "Failed to load map.");

--- a/main.h
+++ b/main.h
@@ -301,5 +301,6 @@ void error_popup(Omni *data, char *fmt, ...);
 void free_linked_changes(ChangeListNode *node);
 void free_linked_states(StateListNode *node);
 int add_state(Omni *data, long long elem);
+const char* crop_to_filename(const char *path);
 
 #endif

--- a/tracker.c
+++ b/tracker.c
@@ -977,6 +977,8 @@ static void file_select_callback(GtkNativeDialog *native, int response, gpointer
 	
 	GtkWidget *dropdown = is_captain ? data->gui_elems.captain_map_dropdown : data->gui_elems.radio_engineer_map_dropdown;
 	
+	g_signal_handlers_block_by_func(GTK_COMBO_BOX(dropdown), is_captain ? (void*)captain_dropdown_fix : (void*)radio_engineer_dropdown_fix, user_data);
+	
 	if(response == GTK_RESPONSE_ACCEPT){
 		GtkFileChooser *chooser = GTK_FILE_CHOOSER(native);
 		GFile *file = gtk_file_chooser_get_file(chooser);
@@ -987,6 +989,8 @@ static void file_select_callback(GtkNativeDialog *native, int response, gpointer
 		
 		if(!init_tracker(data, filename, FROM_FILE, is_captain)){
 			gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(dropdown), GTK_SENSITIVITY_OFF);
+			gtk_combo_box_text_prepend_text(GTK_COMBO_BOX_TEXT(dropdown), crop_to_filename(filename));
+			gtk_combo_box_set_active(GTK_COMBO_BOX(dropdown), 0);
 			refresh_drawing_areas(data, is_captain);
 		}else{
 			gtk_combo_box_set_active(GTK_COMBO_BOX(dropdown), -1);
@@ -997,6 +1001,8 @@ static void file_select_callback(GtkNativeDialog *native, int response, gpointer
 	}else{
 		gtk_combo_box_set_active(GTK_COMBO_BOX(dropdown), -1);
 	}
+	
+	g_signal_handlers_unblock_by_func(GTK_COMBO_BOX(dropdown), is_captain ? (void*)captain_dropdown_fix : (void*)radio_engineer_dropdown_fix, user_data);
 
 	g_object_unref(native);
 }
@@ -1044,7 +1050,9 @@ static int dropdown_fix(GtkComboBoxText *box, gpointer user_data, int is_captain
 						gtk_combo_box_set_button_sensitivity(GTK_COMBO_BOX(box), GTK_SENSITIVITY_OFF);
 						refresh_drawing_areas(data, is_captain);
 					}else{
+						g_signal_handlers_block_by_func(box, is_captain ? (void*)captain_dropdown_fix : (void*)radio_engineer_dropdown_fix, user_data);
 						gtk_combo_box_set_active(GTK_COMBO_BOX(box), -1);
+						g_signal_handlers_unblock_by_func(box, is_captain ? (void*)captain_dropdown_fix : (void*)radio_engineer_dropdown_fix, user_data);
 						error_popup(data, "Failed to load static map.");
 					}
 					g_free(map);


### PR DESCRIPTION
Makes dropdown text show the name of the loaded file when a map is loaded via a CLI arg or via the `Open from File` dropdown option.
Resolves #8