### PR TITLE
fix testbench linker error

### DIFF
--- a/testbench.c
+++ b/testbench.c
@@ -18,6 +18,7 @@
 void error_popup(__attribute__ ((unused)) Omni *data, __attribute__ ((unused)) char *fmt, ...){}
 void free_linked_changes(__attribute__ ((unused)) ChangeListNode *cln){}
 void free_linked_states(__attribute__ ((unused)) StateListNode *sln){}
+const char *crop_to_filename(const char *path) { return path; }
 
 int main()
 {


### PR DESCRIPTION
fixes a linker error caused by the testbench not linking with `main.o` which provided a `crop_to_filename` function (not actually used but needed for linking).
solution: add a spoof function since we really don't need that function anyway.